### PR TITLE
Upgraded dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: win32_gamepad
 description: A package that provides a friendly Dart API for accessing gamepads connected to a Windows machine.
-version: 1.0.2
+version: 1.0.3
 repository: https://github.com/timsneath/win32_gamepad
 issue_tracker: https://github.com/timsneath/win32_gamepad/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,9 @@ platforms:
   windows:
 
 dependencies:
-  ffi: ^1.1.0
-  win32: ^2.4.1
+  ffi: ^2.0.1
+  win32: ^4.1.1
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.0.1
   test: ^1.20.1


### PR DESCRIPTION
Upgrades `ffi`, `win32`, and `lints` to new major versions, which was blocking other packages in Flutter projects. I checked the changelogs for these packages and I didn't see anything that could go wrong, and `flutter analyze` passes on the plugin and the example code. 